### PR TITLE
Fix TypeError for unknown repository

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function read(filepath) {
 var ctx = function (context) {
   var opts = {
     author: context.author.name || author(context.author)[0].name || 'unknown',
-    homepage: context.homepage || context.repo.url || 'unknown',
+    homepage: context.homepage || (context.repository && context.repository.url) || 'unknown',
     license: context.license || 'MIT',
     year: context.year || year()
   };


### PR DESCRIPTION
Heya,
The fallback for the homepage url is to use the git repository url. Unfortunately there was a typo, as the field is called "repository" and not "repo". I just recognized as I did not define a homepage in my package.json file.
I also added another check, just in case someone has not even a git repository defined.

Cheers
Patrick
